### PR TITLE
Changed the APIAccess implementation of the MoveDiscardPileToDeck method (now called MovePileToDeck)

### DIFF
--- a/Tests/data_access/APIAccessTest.java
+++ b/Tests/data_access/APIAccessTest.java
@@ -157,15 +157,15 @@ class APIAccessTest {
     }
 
     @Test
-    void moveDiscardPileToDeck() {
-        // Only used by other methods. Assuming all other methods are correct, the correct values should always be provided
+    void movePileToDeck() {
+        // Assume the provided deck and pile name are correct. Assume all other methods are correct
         try {
             api.DrawCard(testDeck, "discard");
             int currentRemainingCards = testDeck.getRemainingCards();
-            api.MoveDiscardPileToDeck(testDeck);
+            api.MovePileToDeck(testDeck, "discard");
             assert !testDeck.isShuffled() && testDeck.getRemainingCards() == currentRemainingCards + 1;
         } catch (IOException e) {
-            fail("IOEception not expected");
+            fail("IOException not expected");
         }
 
     }

--- a/Tests/data_access/APIAccessTest.java
+++ b/Tests/data_access/APIAccessTest.java
@@ -157,7 +157,7 @@ class APIAccessTest {
     }
 
     @Test
-    void movePileToDeck() {
+    void movePileToDeckSuccessful() {
         // Assume the provided deck and pile name are correct. Assume all other methods are correct
         try {
             api.DrawCard(testDeck, "discard");
@@ -168,6 +168,31 @@ class APIAccessTest {
             fail("IOException not expected");
         }
 
+    }
+
+    @Test
+    void MovePileToDeckInvalidPileName() {
+        try {
+            api.DrawCard(testDeck, "test1");
+            int currentRemainingCards = testDeck.getRemainingCards();
+            api.MovePileToDeck(testDeck, "fail");
+            fail("IOException expected");
+        } catch (IOException e) {
+            assert true;
+        }
+    }
+
+    @Test
+    void MovePileToDeckInvalidDeck() {
+        Deck newDeck = new Deck(true, "249fjn092??", 54);
+        try {
+            api.DrawCard(testDeck, "discard");
+            int currentRemainingCards = testDeck.getRemainingCards();
+            api.MovePileToDeck(newDeck, "discard");
+            fail("IOException expected");
+        } catch (IOException e) {
+            assert true;
+        }
     }
 
     @Test

--- a/src/data_access/APIAccess.java
+++ b/src/data_access/APIAccess.java
@@ -137,7 +137,7 @@ public class APIAccess implements APIAccessInterface {
                 int updatedRemainingCards = Integer.parseInt(newString[8].split(":")[1].replace("}", "").trim());
                 deck.setRemainingCards(updatedRemainingCards);
                 if (deck.getRemainingCards() == 0) {
-                    MoveDiscardPileToDeck(deck);
+                    MovePileToDeck(deck, "discard");
                     Shuffle(deck);
                 }
             }
@@ -219,11 +219,12 @@ public class APIAccess implements APIAccessInterface {
     }
 
     @Override
-    public void MoveDiscardPileToDeck(Deck deck) throws IOException, RuntimeException{
-        // Will move the cards from the discard pile and return them to the main deck
+    public void MovePileToDeck(Deck deck, String pileName) throws IOException, RuntimeException{
+        // Will move the cards from the specified pile return them to the main deck then shuffle the main deck
+        // Will assume the pile name provided is an already created pile in the deck
 
-        // Call API and move cards from discard pile to the main deck of cards
-        String url = "https://www.deckofcardsapi.com/api/deck/" + deck.getDeckID() + "/pile/discard/return/";
+        // Call API and move cards from desired pile to the main deck of cards
+        String url = "https://www.deckofcardsapi.com/api/deck/" + deck.getDeckID() + "/pile/" + pileName + "/return/";
 
         OkHttpClient client = new OkHttpClient().newBuilder().build();
         Request request = new Request.Builder().url(url).build();
@@ -240,24 +241,25 @@ public class APIAccess implements APIAccessInterface {
                 // Check if successful
                 boolean successful = Boolean.parseBoolean(newString[0].split(":")[1].trim());
                 if (!successful) {
-                    throw new RuntimeException("Discard pile was not moved back to deck");
+                    throw new RuntimeException("Pile was not moved back to deck");
                 }
 
                 // Update the number of remaining cards in the deck
                 int updatedRemainingCards = Integer.parseInt(newString[3].split(":")[1]);
                 deck.setRemainingCards(updatedRemainingCards);
 
-                // Update shuffled value for the deck (is no longer shuffled)
-                deck.setShuffled(false);
+                deck.setShuffled(false); // Since the deck is no longer shuffled
+                // Shuffle the main deck
+                Shuffle(deck);
             } else {
-                // else runs when responseBody is null, indicating the discard pile was not moved to the deck, so will
+                // else runs when responseBody is null, indicating the pile was not moved to the deck, so will
                 // throw a RuntimeException
-                throw new RuntimeException("Discard pile was not moved back to deck");
+                throw new RuntimeException("Pile was not moved back to deck");
             }
         } catch (IOException e) {
             throw new IOException(e);
         } catch (RuntimeException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Pile was not moved back to deck");
         }
 
     }

--- a/src/data_access/APIAccess.java
+++ b/src/data_access/APIAccess.java
@@ -245,7 +245,7 @@ public class APIAccess implements APIAccessInterface {
                 }
 
                 // Update the number of remaining cards in the deck
-                int updatedRemainingCards = Integer.parseInt(newString[3].split(":")[1]);
+                int updatedRemainingCards = Integer.parseInt(newString[2].split(":")[1].trim());
                 deck.setRemainingCards(updatedRemainingCards);
 
                 deck.setShuffled(false); // Since the deck is no longer shuffled

--- a/src/interface_adapter/APIAccessInterface.java
+++ b/src/interface_adapter/APIAccessInterface.java
@@ -16,7 +16,7 @@ public interface APIAccessInterface {
 
     public void AddToPile(String deckID, String pileName, String cardCode) throws IOException, RuntimeException;
 
-    public void MoveDiscardPileToDeck(Deck deck) throws IOException, RuntimeException;
+    public void MovePileToDeck(Deck deck, String pileName) throws IOException, RuntimeException;
 
     public String[] GetCardsInPile(Deck deck, String pileName) throws IOException, RuntimeException;
 


### PR DESCRIPTION
Changed the implementation of the MoveDiscardPileToDeck, which is now MovePileToDeck. MovePileToDeck now takes the additional input of a pile name (assuming there is a pile with that name in the given deck), and moves all the cards back into the main deck, and reshuffles the deck. Added two additional tests for the MovePileToDeck method to ensure an IOException was thrown when an incorrect deck or pile name was provided.